### PR TITLE
 Added to the editor the ability to write highlighted code

### DIFF
--- a/src/scripts/components/editor-line/editor-line.html
+++ b/src/scripts/components/editor-line/editor-line.html
@@ -1,4 +1,4 @@
 <div class="editor-line">
   <div class="editor-line-number" data-editor-line-number></div>
-  <div class="editor-line-text" data-editor-line-text></div>
+  <pre class="editor-line-text" data-editor-line-text></pre>
 </div>

--- a/src/scripts/services/dom/dom.js
+++ b/src/scripts/services/dom/dom.js
@@ -6,4 +6,17 @@ _public.parseHtml = htmlString => {
   return doc.querySelector('body').firstChild;
 };
 
+_public.wrapHtmlStringInHtmlTag = (htmlString, tagName) => {
+  return `<${tagName}>${htmlString}</${tagName}>`;
+};
+
+_public.clearNodeContent = node => {
+  node.innerHTML = '';
+  return node;
+};
+
+_public.isHtmlNodeTypeText = node => {
+  return node && node.nodeName.toLowerCase() == '#text';
+};
+
 export default _public;

--- a/src/scripts/services/dom/dom.test.js
+++ b/src/scripts/services/dom/dom.test.js
@@ -2,10 +2,35 @@ import domService from './dom';
 
 describe('DOM Service', () => {
 
+  function createElement(tagName){
+    return document.createElement(tagName);
+  }
+
   it('should parse an html from string', () => {
     const element = domService.parseHtml('<h1>Hello <span>World</span>!</h1>');
     const span = element.querySelector('span');
     expect(span.innerHTML).toEqual('World');
+  });
+
+  it('should wrap html string in html tag', () => {
+    const htmlString = '<h1>Hello</h1>';
+    const wrappedHtmlString = domService.wrapHtmlStringInHtmlTag(htmlString, 'div');
+    expect(wrappedHtmlString).toEqual(`<div>${htmlString}</div>`);
+  });
+
+  it('should clear some node content', () => {
+    const node = createElement('div');
+    node.innertText = 'Rafael';
+    const clearedNode = domService.clearNodeContent(node);
+    expect(clearedNode.innerHTML).toEqual('');
+  });
+
+  it('should identify text html nodes', () => {
+    const notTextNode = createElement('div');
+    notTextNode.append('Some text');
+    const textNode = Array.from(notTextNode.childNodes)[0];
+    expect(domService.isHtmlNodeTypeText(notTextNode)).toEqual(false);
+    expect(domService.isHtmlNodeTypeText(textNode)).toEqual(true);
   });
 
 });

--- a/src/scripts/services/text/text.js
+++ b/src/scripts/services/text/text.js
@@ -15,4 +15,8 @@ _public.removeBlankFirstLine = text => {
   return lines;
 };
 
+_public.containsHtml = text => {
+  return text.includes('<');
+};
+
 export default _public;

--- a/src/scripts/services/text/text.test.js
+++ b/src/scripts/services/text/text.test.js
@@ -30,4 +30,9 @@ third line`;
     expect(textService.removeBlankFirstLine(text)).toEqual(['first line']);
   });
 
+  it('should identify text that contains html', () => {
+    const text = 'some <strong>bold</strong> text';
+    expect(textService.containsHtml(text)).toEqual(true);
+  });
+
 });

--- a/src/scripts/services/type-html-text/type-html-text.js
+++ b/src/scripts/services/type-html-text/type-html-text.js
@@ -1,0 +1,42 @@
+import domService from '../dom/dom';
+import typePlainTextService from '../type-plain-text/type-plain-text';
+
+const _public = {};
+
+_public.type = (container, htmlString, onComplete) => {
+  const nodes = buildHtmlNodes(htmlString);
+  typeHtmlNodes(container, nodes, onComplete);
+};
+
+function buildHtmlNodes(htmlString){
+  const wrappedHtmlString = domService.wrapHtmlStringInHtmlTag(htmlString, 'span');
+  const html = domService.parseHtml(wrappedHtmlString);
+  return Array.from(html.childNodes);
+}
+
+function typeHtmlNodes(container, nodes, onComplete){
+  if(!nodes.length)
+    return onComplete();
+  typeSingleHtmlNode(container, nodes.shift(), () => {
+    typeHtmlNodes(container, nodes, onComplete);
+  });
+}
+
+function typeSingleHtmlNode(container, node, onComplete){
+  if(domService.isHtmlNodeTypeText(node))
+    typePlainText(node.textContent, container, onComplete);
+  else
+    typePlainText(node.innerHTML, buildSubContainer(container, node), onComplete);
+}
+
+function buildSubContainer(container, node){
+  const subContainer = domService.clearNodeContent(node);
+  container.appendChild(subContainer);
+  return subContainer;
+}
+
+function typePlainText(text, container, onComplete){
+  typePlainTextService.type(container, text, onComplete);
+}
+
+export default _public;

--- a/src/scripts/services/type-html-text/type-html-text.test.js
+++ b/src/scripts/services/type-html-text/type-html-text.test.js
@@ -1,0 +1,37 @@
+import typePlainTextService from '../type-plain-text/type-plain-text';
+import typeHtmlTextService from './type-html-text';
+
+describe('Type Html Text Service', () => {
+
+  function createElement(tagName){
+    return document.createElement(tagName);
+  }
+
+  beforeEach(() => {
+    spyOn(typePlainTextService, 'type').and.callFake((container, text, onComplete) => {
+      onComplete();
+    });
+  });
+
+  it('should type some html text', () => {
+    const container = createElement('div');
+    const htmlString = 'some <span>text</span>';
+    const onComplete = jest.fn();
+    typeHtmlTextService.type(container, htmlString, onComplete);
+    expect(typePlainTextService.type.calls.allArgs()[0][0]).toEqual(container);
+    expect(typePlainTextService.type.calls.allArgs()[0][1]).toEqual('some ');
+    expect(typeof typePlainTextService.type.calls.allArgs()[0][2]).toEqual('function');
+    expect(typePlainTextService.type.calls.allArgs()[1][0]).toEqual(createElement('span'));
+    expect(typePlainTextService.type.calls.allArgs()[1][1]).toEqual('text');
+    expect(typeof typePlainTextService.type.calls.allArgs()[1][2]).toEqual('function');
+  });
+
+  it('should execute on complete callback on complete', () => {
+    const container = createElement('div');
+    const htmlString = 'some <span>text</span>';
+    const onComplete = jest.fn();
+    typeHtmlTextService.type(container, htmlString, onComplete);
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+});

--- a/src/scripts/services/type-plain-text/type-plain-text.js
+++ b/src/scripts/services/type-plain-text/type-plain-text.js
@@ -1,0 +1,16 @@
+const _public = {};
+
+_public.type = (container, text, onComplete) => {
+  const letters = text.split('');
+  const letter = letters.shift();
+  if(letter) {
+    container.append(letter);
+    setTimeout(() => {
+      _public.type(container, letters.join(''), onComplete);
+    }, 75);
+  } else {
+    onComplete();
+  }
+}
+
+export default _public;

--- a/src/scripts/services/type-plain-text/type-plain-text.test.js
+++ b/src/scripts/services/type-plain-text/type-plain-text.test.js
@@ -1,0 +1,33 @@
+import typePlainTextService from './type-plain-text';
+
+describe('Type Plain Text Service', () => {
+
+  let onCompleteCallbackMock;
+
+  jest.useFakeTimers();
+
+  function mockOnCompleteCallback(){
+    onCompleteCallbackMock = jest.fn();
+  }
+
+  beforeEach(() => {
+    mockOnCompleteCallback();
+  });
+
+  it('should type some plain text', () => {
+    const containerElement = document.createElement('div');
+    const textToBeTyped = 'Typed!';
+    typePlainTextService.type(containerElement, textToBeTyped, onCompleteCallbackMock);
+    jest.runAllTimers();
+    expect(containerElement.innerHTML).toEqual(textToBeTyped);
+  });
+
+  it('should callback after type some plain text', () => {
+    const containerElement = document.createElement('div');
+    const textToBeTyped = 'Typed!';
+    typePlainTextService.type(containerElement, textToBeTyped, onCompleteCallbackMock);
+    jest.runAllTimers();
+    expect(onCompleteCallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+});

--- a/src/scripts/services/type/type.js
+++ b/src/scripts/services/type/type.js
@@ -1,16 +1,14 @@
+import textService from '../text/text';
+import typePlainTextService from '../type-plain-text/type-plain-text';
+import typeHtmlTextService from '../type-html-text/type-html-text';
+
 const _public = {};
 
 _public.type = (container, text, onComplete) => {
-  const letters = text.split('');
-  const letter = letters.shift();
-  if(letter) {
-    container.append(letter);
-    setTimeout(() => {
-      _public.type(container, letters.join(''), onComplete);
-    }, 75);
-  } else {
-    onComplete();
-  }
-}
+  if(textService.containsHtml(text))
+    typeHtmlTextService.type(container, text, onComplete);
+  else
+    typePlainTextService.type(container, text, onComplete);
+};
 
 export default _public;

--- a/src/scripts/services/type/type.test.js
+++ b/src/scripts/services/type/type.test.js
@@ -1,33 +1,39 @@
 import typeService from './type';
+import textService from '../text/text';
+import typeHtmlTextService from '../type-html-text/type-html-text';
+import typePlainTextService from '../type-plain-text/type-plain-text';
 
 describe('Type Service', () => {
 
-  let onCompleteCallbackMock;
-
-  jest.useFakeTimers();
+  function mockContainer(){
+    return document.createElement('div');
+  }
 
   function mockOnCompleteCallback(){
-    onCompleteCallbackMock = jest.fn();
+    return jest.fn();
   }
 
   beforeEach(() => {
-    mockOnCompleteCallback();
+    spyOn(typeHtmlTextService, 'type');
+    spyOn(typePlainTextService, 'type');
+  })
+
+  it('should type some plain text', () => {
+    const container = mockContainer();
+    const onComplete = mockOnCompleteCallback();
+    const text = 'just plain text';
+    spyOn(textService, 'containsHtml').and.returnValue(false);
+    typeService.type(container, text, onComplete);
+    expect(typePlainTextService.type).toHaveBeenCalledWith(container, text, onComplete);
   });
 
-  it('should type some text', () => {
-    const containerElement = document.createElement('div');
-    const textToBeTyped = 'Typed!';
-    typeService.type(containerElement, textToBeTyped, onCompleteCallbackMock);
-    jest.runAllTimers();
-    expect(containerElement.innerHTML).toEqual(textToBeTyped);
-  });
-
-  it('should callback after type some text', () => {
-    const containerElement = document.createElement('div');
-    const textToBeTyped = 'Typed!';
-    typeService.type(containerElement, textToBeTyped, onCompleteCallbackMock);
-    jest.runAllTimers();
-    expect(onCompleteCallbackMock).toHaveBeenCalledTimes(1);
+  it('should type some html text', () => {
+    const container = mockContainer();
+    const onComplete = mockOnCompleteCallback();
+    const text = 'this is <strong>bold</strong>';
+    spyOn(textService, 'containsHtml').and.returnValue(true);
+    typeService.type(container, text, onComplete);
+    expect(typeHtmlTextService.type).toHaveBeenCalledWith(container, text, onComplete);
   });
 
 });


### PR DESCRIPTION
Resolves #2 

Added to type service the ability to type html text:

``` javascript
import '@glorious/demo/gdemo.min.css';
import 'prismjs/themes/prism-tomorrow.css'; // My favorite Prism theme
import GDemo from '@glorious/demo';
import Prism from 'prismjs';
import 'prismjs/components/prism-ruby.js'; // Using language other than html/css/js

const demo = new GDemo('#container');

const code = `
def greet
  printf "Hello World!"
end

greet()
`

const highlightedCode = Prism.highlight(code, Prism.languages.ruby, 'ruby');

demo
  .openApp('editor', {minHeight: '350px', windowTitle: '~/gdemo.rb'})
  .write(highlightedCode)
  .end();
```

<img width="582" alt="screen shot 2018-08-19 at 19 46 33" src="https://user-images.githubusercontent.com/4738687/44313987-a45b7f00-a3e8-11e8-8de9-171539779743.png">
